### PR TITLE
Feature Update 2019 January

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     role_session_name: "{{ (lookup('env', 'USER') + '@' + ansible_product_name + '.' + ansible_product_serial) | regex_replace('[^\\w+=,.@-]', '-')}}"
   register: assumed_role
 
-- name: Find AMI
+- name: Find the AMI
   ec2_ami_facts:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
@@ -22,17 +22,17 @@
     image_id: "{{ ami_id }}"
   register: ami
 
-- name: AMI Found
+- name: The AMI is Found
   debug:
     msg: "{{ ami.images }}"
     verbosity: 3
 
-- name: Error When Finding the AMI
+- name: Fail If the AMI Is Not Found
   fail:
     msg: "Got {{ ami.images|length }} ami, expected 1. Please check `ami_id` parameter."
   when: ami.images|length != 1
 
-- name: Find ASG
+- name: Find the ASG
   ec2_asg_facts:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
@@ -41,22 +41,22 @@
     name: "{{ asg_name }}"
   register: asg
 
-- name: ASG Found
+- name: The ASG Is Found
   debug:
     msg: "{{ asg.results }}"
     verbosity: 3
 
-- name: Error When Finding the ASG
+- name: Fail If the ASG Is Not Found
   fail:
     msg: "Got {{ asg.results|length }} asg, expected 1. Please check `asg_name` parameter."
   when: asg.results|length != 1
 
-- name: Set Launch Configurations' Name
+- name: Set Launch Configurations Names
   set_fact:
     old_lc_name: "{{ asg.results[0].launch_configuration_name }}"
-    new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ service_version }}-{{ ami.images[0].image_id }}-{{ service_environment }}-{{ launch_configuration_name_suffix }}"
+    new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ launch_configuration_name_suffix }}"
 
-- name: Find Old Launch Configuration
+- name: Find the Old Launch Configuration
   ec2_lc_facts:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
@@ -65,12 +65,12 @@
     name: "{{ old_lc_name }}"
   register: old_lc
 
-- name: Launch Configuration Found
+- name: The Old Launch Configuration Is Found
   debug:
     msg: "{{ old_lc.launch_configurations }}"
     verbosity: 3
 
-- name: Error When Finding the Old Launch Configuration
+- name: Fail If the AMI Is Not Found
   fail:
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
@@ -114,6 +114,9 @@
     replace_batch_size: "{{ asg_replace_batch_size | default(omit) }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
+    tags:
+      - AmiId: "{{ ami.images[0].image_id }}"
+        propagate_at_launch: yes
 
 - name: Delete the Old Launch Configuration
   ec2_lc:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,9 +114,7 @@
     replace_batch_size: "{{ asg_replace_batch_size | default(omit) }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
-    tags:
-      - AmiId: "{{ ami.images[0].image_id }}"
-        propagate_at_launch: yes
+    tags: "{{ asg.results[0].tags + [{ 'AmiId': ami.images[0].image_id, 'propagate_at_launch': 'yes' }] }}"
 
 - name: Delete the Old Launch Configuration
   ec2_lc:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
 - name: Set Launch Configurations Names
   set_fact:
     old_lc_name: "{{ asg.results[0].launch_configuration_name }}"
-    new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ launch_configuration_name_suffix }}"
+    new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ ansible_date_time.iso8601_basic_short }}-{{ launch_configuration_name_suffix }}"
 
 - name: Find the Old Launch Configuration
   ec2_lc_facts:
@@ -114,7 +114,6 @@
     replace_batch_size: "{{ asg_replace_batch_size | default(omit) }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
-    tags: "{{ asg.results[0].tags + [{ 'AmiId': ami.images[0].image_id, 'propagate_at_launch': 'yes' }] }}"
 
 - name: Delete the Old Launch Configuration
   ec2_lc:


### PR DESCRIPTION
- always do rolling update even with the same AMI (feedback from by @mickykurniawan, @febryanm,  @mage95, @andrewsaputra, and other engineers). This turns out to be more preferable than idempotent as people *do* redeploy same AMIs to restart their services quickly. This also enable deploying the same AMI while editing the launch config parameters (e.g. instance type, security group, userdata)
- remove the need of `service_version` parameter (feedback from by @mickykurniawan, @febryanm, @mage95). This way the (manual) deployment can be done faster, as we'll need less parameters
- reword task names to make them less confusing (feedback from @febryanm, @mage95)