### PR TITLE
Feature Update 201901-2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,10 @@
 asg_default_cooldown: 300
 asg_wait_timeout: 3600
 asg_wait_for_instances: true
+asg_metrics_collection: true
 ebs_device_name: /dev/sda1
 ebs_volume_size: 8
 ebs_volume_type: gp2
 ebs_delete_on_termination: true
 launch_configuration_name_suffix: rolling
+always_roll: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,6 @@
 asg_default_cooldown: 300
 asg_wait_timeout: 3600
 asg_wait_for_instances: true
-asg_metrics_collection: true
 ebs_device_name: /dev/sda1
 ebs_volume_size: 8
 ebs_volume_type: gp2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,4 @@ ebs_volume_size: 8
 ebs_volume_type: gp2
 ebs_delete_on_termination: true
 launch_configuration_name_suffix: rolling
-always_roll: true
+replace_new_instances: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check Ansible Version
   fail:
-    msg: "Detected ansible version is {{ ansible_version.full }}, please use 2.5.8 <= version <= 2.7.4"
-  when: ansible_version.full is version('2.7.4', '>') or ansible_version.full is version('2.5.8', '<')
+    msg: "Detected ansible version is {{ ansible_version.full }}, please use ansible v2.5.x"
+  when: ansible_version.full is version('2.5.14', '>') or ansible_version.full is version('2.5.0', '<')
 
 - name: Assume ProductDomainAdmin Role
   sts_assume_role:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     role_session_name: "{{ (lookup('env', 'USER') + '@' + ansible_product_name + '.' + ansible_product_serial) | regex_replace('[^\\w+=,.@-]', '-')}}"
   register: assumed_role
 
-- name: Find the AMI
+- name: Get the AMI
   ec2_ami_facts:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
@@ -32,7 +32,7 @@
     msg: "Got {{ ami.images|length }} ami, expected 1. Please check `ami_id` parameter."
   when: ami.images|length != 1
 
-- name: Find the ASG
+- name: Get the ASG
   ec2_asg_facts:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
@@ -51,12 +51,21 @@
     msg: "Got {{ asg.results|length }} asg, expected 1. Please check `asg_name` parameter."
   when: asg.results|length != 1
 
-- name: Set Launch Configurations Names
+- name: Get Old Launch Configuration Name
   set_fact:
     old_lc_name: "{{ asg.results[0].launch_configuration_name }}"
-    new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ ansible_date_time.iso8601_basic_short }}-{{ launch_configuration_name_suffix }}"
 
-- name: Find the Old Launch Configuration
+- name: Set Always-Rolling Launch Configuration Name
+  set_fact:
+    new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ ansible_date_time.iso8601_basic_short }}-{{ launch_configuration_name_suffix }}"
+  when: always_roll == True
+
+- name: Set Idempotent Launch Configuration Name
+  set_fact:
+    new_lc_name: "{{ asg.results[0].launch_configuration_name }}"
+  when: always_roll == False
+
+- name: Get the Old Launch Configuration
   ec2_lc_facts:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
@@ -70,7 +79,7 @@
     msg: "{{ old_lc.launch_configurations }}"
     verbosity: 3
 
-- name: Fail If the AMI Is Not Found
+- name: Fail If the Old Launch Configuration Is Not Found
   fail:
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
@@ -103,7 +112,7 @@
     region: "{{ aws_region }}"
     default_cooldown: "{{ asg_default_cooldown }}"
     name: "{{ asg_name }}"
-    metrics_collection: yes
+    metrics_collection: "{{ asg_metrics_collection }}"
     launch_config_name: "{{ new_lc_name }}"
     max_size: "{{ asg_max_size | default(asg.results[0].max_size) }}"
     min_size: "{{ asg_min_size | default(asg.results[0].min_size) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Check Ansible Version
   fail:
-    msg: "Detected ansible version is {{ ansible_version.full }}, please use 2.6.0 <= version <= 2.7.4"
-  when: ansible_version.full is version('2.7.4', '>') or ansible_version.full is version('2.6.0', '<')
+    msg: "Detected ansible version is {{ ansible_version.full }}, please use 2.5.8 <= version <= 2.7.4"
+  when: ansible_version.full is version('2.7.4', '>') or ansible_version.full is version('2.5.8', '<')
 
 - name: Assume ProductDomainAdmin Role
   sts_assume_role:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,7 +112,7 @@
     region: "{{ aws_region }}"
     default_cooldown: "{{ asg_default_cooldown }}"
     name: "{{ asg_name }}"
-    metrics_collection: "{{ asg_metrics_collection }}"
+    metrics_collection: "{{ asg_metrics_collection | default(omit) }}"
     launch_config_name: "{{ new_lc_name }}"
     max_size: "{{ asg_max_size | default(asg.results[0].max_size) }}"
     min_size: "{{ asg_min_size | default(asg.results[0].min_size) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ ansible_date_time.iso8601_basic_short }}-{{ launch_configuration_name_suffix }}"
   when: replace_new_instances
 
-- name: Reinstante Current Launch Configuration Name
+- name: Reinstate Current Launch Configuration Name
   set_fact:
     new_lc_name: "{{ asg.results[0].launch_configuration_name }}"
   when: not replace_new_instances
@@ -84,7 +84,7 @@
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
 
-- name: Create New Launch Configuration
+- name: State the Launch Configuration
   ec2_lc:
     aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
     aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,15 +55,15 @@
   set_fact:
     old_lc_name: "{{ asg.results[0].launch_configuration_name }}"
 
-- name: Set Always-Rolling Launch Configuration Name
+- name: Set New Launch Configuration Name
   set_fact:
     new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ ansible_date_time.iso8601_basic_short }}-{{ launch_configuration_name_suffix }}"
-  when: always_roll == True
+  when: replace_new_instances == True
 
-- name: Set Idempotent Launch Configuration Name
+- name: Reinstante Current Launch Configuration Name
   set_fact:
     new_lc_name: "{{ asg.results[0].launch_configuration_name }}"
-  when: always_roll == False
+  when: replace_new_instances == False
 
 - name: Get the Old Launch Configuration
   ec2_lc_facts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,7 +112,6 @@
     region: "{{ aws_region }}"
     default_cooldown: "{{ asg_default_cooldown }}"
     name: "{{ asg_name }}"
-    metrics_collection: "{{ asg_metrics_collection | default(omit) }}"
     launch_config_name: "{{ new_lc_name }}"
     max_size: "{{ asg_max_size | default(asg.results[0].max_size) }}"
     min_size: "{{ asg_min_size | default(asg.results[0].min_size) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
 
 - name: Fail If the AMI Is Not Found
   fail:
-    msg: "Got {{ ami.images|length }} ami, expected 1. Please check `ami_id` parameter."
+    msg: "Got {{ ami.images|length }} AMI(s), expected 1. Please check `ami_id` parameter."
   when: ami.images|length != 1
 
 - name: Get the ASG
@@ -58,12 +58,12 @@
 - name: Set New Launch Configuration Name
   set_fact:
     new_lc_name: "{{ service_name }}-{{ cluster_role }}-{{ ami.images[0].name }}-{{ service_environment }}-{{ ansible_date_time.iso8601_basic_short }}-{{ launch_configuration_name_suffix }}"
-  when: replace_new_instances == True
+  when: replace_new_instances
 
 - name: Reinstante Current Launch Configuration Name
   set_fact:
     new_lc_name: "{{ asg.results[0].launch_configuration_name }}"
-  when: replace_new_instances == False
+  when: not replace_new_instances
 
 - name: Get the Old Launch Configuration
   ec2_lc_facts:


### PR DESCRIPTION
- add switch to replace current instances or reinstate previous executions, in case of interrupted deployments
- remove `metrics_collection`, see the comment