### PR TITLE
keep launch config keyname

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,6 +94,7 @@
     image_id: "{{ ami.images[0].image_id }}"
     instance_type: "{{ instance_type | default(old_lc.launch_configurations[0].instance_type) }}"
     instance_profile_name: "{{ old_lc.launch_configurations[0].iam_instance_profile }}"
+    key_name: "{{ old_lc.launch_configurations[0].key_name | default(omit) }}"
     security_groups: "{{ old_lc.launch_configurations[0].security_groups }}"
     user_data: "{{ instance_user_data }}"
     instance_monitoring: "{{ old_lc.launch_configurations[0].instance_monitoring.enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
     image_id: "{{ ami.images[0].image_id }}"
     instance_type: "{{ instance_type | default(old_lc.launch_configurations[0].instance_type) }}"
     instance_profile_name: "{{ old_lc.launch_configurations[0].iam_instance_profile }}"
-    key_name: "{{ old_lc.launch_configurations[0].key_name | default(omit) }}"
+    key_name: "{{ old_lc.launch_configurations[0].key_name | default(omit, true) }}"
     security_groups: "{{ old_lc.launch_configurations[0].security_groups }}"
     user_data: "{{ instance_user_data }}"
     instance_monitoring: "{{ old_lc.launch_configurations[0].instance_monitoring.enabled }}"


### PR DESCRIPTION
This diff enables ec2 keyname preservation. The key will be retrieved from the previous launch configuration. The `key_name` is always returned from [ec2_lc_facts](https://docs.ansible.com/ansible/2.5/modules/ec2_lc_facts_module.html). If it's empty, jinja2 `default` filter's second parameter (`true`)  will make the `key_name` parameter omitted