### PR TITLE
Remove usage of ansible_product_name predefine variable.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     mfa_serial_number: "{{ aws_mfa_serial | default(omit) }}"
     mfa_token: "{{ aws_mfa_token | default(omit) }}"
     region: "{{ aws_region }}"
-    role_session_name: "{{ (lookup('env', 'USER') + '@' + ansible_product_name + '.' + ansible_product_serial) | regex_replace('[^\\w+=,.@-]', '-')}}"
+    role_session_name: "{{ (lookup('env', 'USER') + ansible_product_serial) | regex_replace('[^\\w+=,.@-]', '-')}}"
   register: assumed_role
 
 - name: Get the AMI


### PR DESCRIPTION
`ansible_product_name` is a predefined variable, which is not working for all machine, especially mac os, and blocking them to deploy to auto scaling, this PR is to remove the usage of `ansible_product_name` variable.
error_msg:
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible_product_name' is undefined\n\nThe error appears to have been in '/Users/username/.ansible/roles/ansible-blue_green-lc-deploy/tasks/main.yml': line 7, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Assume ProductDomainAdmin Role\n  ^ here\n