### PR TITLE
Remove ansible_product_serial predefine variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     mfa_serial_number: "{{ aws_mfa_serial | default(omit) }}"
     mfa_token: "{{ aws_mfa_token | default(omit) }}"
     region: "{{ aws_region }}"
-    role_session_name: "{{ (lookup('env', 'USER') + ansible_product_serial) | regex_replace('[^\\w+=,.@-]', '-')}}"
+    role_session_name: "{{ (lookup('env', 'USER')) | regex_replace('[^\\w+=,.@-]', '-')}}"
   register: assumed_role
 
 - name: Get the AMI


### PR DESCRIPTION
## Summary
Remove unexist prefined variable ansible_product* on MacOs, this is a known bug for ansible and we already created issue as well on ansible repo #https://github.com/ansible/ansible/issues/52233. To fix this we can remove the usage of ansible_product* variable from our playbook.

## Issue
#12 

## Test Plan
- Create requirements.yml file to download roles from https://github.com/traveloka/ansible-blue_green-lc-deploy.git
- Download ansible-role ansible-galaxy -f requirements.yml
- Create ansible playbook, see https://github.com/traveloka/ansible-blue_green-lc-deploy#example-playbook
- Run ansible playbook on check mode.

## Subscribers
- @salvianreynaldi 
- @rafikurnia 
- @bobbypriambodo 